### PR TITLE
Add DriftGuard drift detection workflow

### DIFF
--- a/.github/workflows/driftguard.yml
+++ b/.github/workflows/driftguard.yml
@@ -1,0 +1,46 @@
+name: DriftGuard
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+  pull_request:
+
+jobs:
+  driftguard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q
+      - name: Run DriftGuard sample
+        run: |
+          python -m scripts.driftguard \
+            --inventory inventory.yml \
+            --configs configs \
+            --rules rules \
+            --out out/drift \
+            --render-remediation \
+            --fail-on critical \
+            --offline
+      - name: Upload DriftGuard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: driftguard-artifacts
+          path: |
+            out/drift/drift_report.md
+            out/drift/drift_report.json
+            out/drift/metrics.json
+            out/drift/diffs/
+            out/drift/remediation/
+            out/drift/plan.md
+            out/drift/plan.json

--- a/configs/sample/baseline/core-sw01.cfg
+++ b/configs/sample/baseline/core-sw01.cfg
@@ -1,0 +1,7 @@
+hostname core-sw01
+ntp server 1.1.1.1
+ntp server 1.0.0.1
+!
+interface GigabitEthernet0/1
+ description Uplink to core
+!

--- a/configs/sample/baseline/edge-rtr01.cfg
+++ b/configs/sample/baseline/edge-rtr01.cfg
@@ -1,0 +1,7 @@
+hostname edge-rtr01
+ntp server 1.1.1.1
+ntp server 1.0.0.1
+!
+interface GigabitEthernet0/0
+ description Uplink to ISP
+!

--- a/configs/sample/core-sw01.running.cfg
+++ b/configs/sample/core-sw01.running.cfg
@@ -1,0 +1,7 @@
+hostname core-sw01
+ip http server
+ntp server 1.1.1.1
+!
+interface GigabitEthernet0/1
+ description Uplink to core
+!

--- a/configs/sample/edge-rtr01.running.cfg
+++ b/configs/sample/edge-rtr01.running.cfg
@@ -1,0 +1,7 @@
+hostname edge-rtr01
+ntp server 1.1.1.1
+ntp server 1.0.0.1
+!
+interface GigabitEthernet0/0
+ description Uplink to ISP
+!

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,0 +1,9 @@
+devices:
+  - name: core-sw01
+    platform: cisco_ios
+    running: sample/core-sw01.running.cfg
+    baseline: sample/baseline/core-sw01.cfg
+  - name: edge-rtr01
+    platform: cisco_ios
+    running: sample/edge-rtr01.running.cfg
+    baseline: sample/baseline/edge-rtr01.cfg

--- a/onyxlib/__init__.py
+++ b/onyxlib/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for Onyx network automation tooling."""

--- a/onyxlib/drift/__init__.py
+++ b/onyxlib/drift/__init__.py
@@ -1,0 +1,19 @@
+"""Drift detection utilities."""
+
+from .loader import load_inventory, load_device_configs
+from .normalizer import normalize_config
+from .rules import RulesEngine, RuleResult
+from .diff import build_diff
+from .remediation import build_change_plan
+from .report import DriftReport
+
+__all__ = [
+    "load_inventory",
+    "load_device_configs",
+    "normalize_config",
+    "RulesEngine",
+    "RuleResult",
+    "build_diff",
+    "build_change_plan",
+    "DriftReport",
+]

--- a/onyxlib/drift/diff.py
+++ b/onyxlib/drift/diff.py
@@ -1,0 +1,44 @@
+"""Diff helpers for configuration drift."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import difflib
+
+
+@dataclass
+class DiffResult:
+    device: str
+    diff_text: str
+    line_count: int
+    diff_path: Path
+
+
+def build_diff(device: str, baseline_lines: Iterable[str], running_lines: Iterable[str], out_dir: Path) -> DiffResult:
+    """Create a unified diff for a device and persist it to disk."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    diff_path = out_dir / f"{device}.diff"
+
+    baseline_list = list(baseline_lines)
+    running_list = list(running_lines)
+
+    diff_lines = list(
+        difflib.unified_diff(
+            baseline_list,
+            running_list,
+            fromfile=f"{device} (baseline)",
+            tofile=f"{device} (running)",
+            lineterm="",
+        )
+    )
+
+    diff_text = "\n".join(diff_lines)
+    diff_path.write_text(diff_text)
+
+    line_count = sum(1 for line in diff_lines if line.startswith(('+', '-')) and not line.startswith(('+++', '---')))
+
+    return DiffResult(device=device, diff_text=diff_text, line_count=line_count, diff_path=diff_path)

--- a/onyxlib/drift/loader.py
+++ b/onyxlib/drift/loader.py
@@ -1,0 +1,110 @@
+"""Helpers for loading inventory and configuration data for drift detection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import yaml
+
+
+@dataclass
+class DeviceRecord:
+    """Represents a device entry from the inventory file."""
+
+    name: str
+    platform: str
+    running_config: str
+    baseline_config: Optional[str]
+    running_path: Path
+    baseline_path: Optional[Path]
+
+
+def load_inventory(path: Path) -> List[Dict[str, object]]:
+    """Load a YAML inventory file."""
+
+    data = yaml.safe_load(Path(path).read_text())
+    if not isinstance(data, dict) or "devices" not in data:
+        raise ValueError("Inventory must be a mapping with a 'devices' key")
+    devices = data["devices"]
+    if not isinstance(devices, list):
+        raise ValueError("Inventory 'devices' must be a list")
+    return devices
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"Expected configuration file at {path}")
+    return path.read_text().strip()
+
+
+def _candidate_paths(root: Path, name: str, preferred: Optional[str]) -> Iterable[Path]:
+    if preferred:
+        yield (root / preferred)
+    patterns = [
+        f"{name}.cfg",
+        f"{name}.conf",
+        f"{name}.txt",
+        f"{name}.running",
+        f"{name}.running.cfg",
+    ]
+    for pattern in patterns:
+        yield root / pattern
+
+
+def _candidate_baselines(root: Path, name: str, preferred: Optional[str]) -> Iterable[Path]:
+    if preferred:
+        yield root / preferred
+    subdirs = [root / "baseline", root / "baselines", root / "golden"]
+    for subdir in subdirs:
+        if preferred:
+            yield subdir / preferred
+        for suffix in (".cfg", ".conf", ".txt", ".golden.cfg", ".baseline", ".baseline.cfg"):
+            yield subdir / f"{name}{suffix}"
+    for suffix in (".baseline", ".baseline.cfg", ".golden", ".golden.cfg"):
+        yield root / f"{name}{suffix}"
+
+
+def _first_existing(paths: Iterable[Path]) -> Optional[Path]:
+    for candidate in paths:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def load_device_configs(inventory: List[Dict[str, object]], configs_dir: Path) -> List[DeviceRecord]:
+    """Resolve configuration paths for each device in the inventory."""
+
+    records: List[DeviceRecord] = []
+    configs_root = Path(configs_dir)
+
+    for entry in inventory:
+        if not isinstance(entry, dict):
+            raise ValueError("Inventory entries must be mappings")
+        name = str(entry.get("name"))
+        platform = str(entry.get("platform", "unknown"))
+        running_hint = entry.get("running") or entry.get("running_config") or entry.get("config")
+        baseline_hint = entry.get("baseline") or entry.get("baseline_config")
+
+        running_path = _first_existing(_candidate_paths(configs_root, name, running_hint if isinstance(running_hint, str) else None))
+        if running_path is None:
+            raise FileNotFoundError(f"Unable to locate running config for {name}")
+
+        baseline_path = _first_existing(_candidate_baselines(configs_root, name, baseline_hint if isinstance(baseline_hint, str) else None))
+
+        running_config = _read_text(running_path)
+        baseline_config = _read_text(baseline_path) if baseline_path else None
+
+        records.append(
+            DeviceRecord(
+                name=name,
+                platform=platform,
+                running_config=running_config,
+                baseline_config=baseline_config,
+                running_path=running_path,
+                baseline_path=baseline_path,
+            )
+        )
+
+    return records

--- a/onyxlib/drift/normalizer.py
+++ b/onyxlib/drift/normalizer.py
@@ -1,0 +1,29 @@
+"""Configuration normalization utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+
+IGNORED_PREFIXES = ("!", "#")
+
+
+def normalize_config(config_text: str) -> List[str]:
+    """Normalize a raw configuration into comparable logical lines."""
+
+    normalized: List[str] = []
+    for raw_line in config_text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(IGNORED_PREFIXES):
+            continue
+        collapsed = " ".join(stripped.split())
+        normalized.append(collapsed)
+    return normalized
+
+
+def join_lines(lines: Iterable[str]) -> str:
+    """Join normalized lines for string based matching."""
+
+    return "\n".join(lines)

--- a/onyxlib/drift/remediation.py
+++ b/onyxlib/drift/remediation.py
@@ -1,0 +1,88 @@
+"""Utilities for building remediation previews."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+from .rules import RuleResult
+
+
+@dataclass
+class RemediationSnippet:
+    device: str
+    commands: Sequence[str]
+    path: Path
+    rule_ids: Sequence[str]
+
+
+@dataclass
+class ChangePlan:
+    plan_md: Path
+    plan_json: Path
+    snippets: List[RemediationSnippet]
+
+
+def build_remediation_snippets(device: str, results: Sequence[RuleResult], out_dir: Path) -> List[RemediationSnippet]:
+    snippets: List[RemediationSnippet] = []
+    remediation_dir = out_dir / "remediation"
+    remediation_dir.mkdir(parents=True, exist_ok=True)
+
+    for result in results:
+        if result.passed or not result.rule.remediation:
+            continue
+        commands = list(result.rule.remediation)
+        path = remediation_dir / f"{device}__{result.rule.rule_id}.txt"
+        header = [f"! remediation for {device} rule {result.rule.rule_id}"]
+        path.write_text("\n".join(header + list(commands)) + "\n")
+        snippets.append(
+            RemediationSnippet(
+                device=device,
+                commands=commands,
+                path=path,
+                rule_ids=[result.rule.rule_id],
+            )
+        )
+    return snippets
+
+
+def build_change_plan(device_results: Dict[str, Sequence[RuleResult]], out_dir: Path) -> ChangePlan:
+    """Create a markdown and JSON change plan for remediation."""
+
+    plan_dir = Path(out_dir)
+    plan_dir.mkdir(parents=True, exist_ok=True)
+
+    all_snippets: List[RemediationSnippet] = []
+    for device, results in device_results.items():
+        all_snippets.extend(build_remediation_snippets(device, results, plan_dir))
+
+    plan_md = plan_dir / "plan.md"
+    plan_json = plan_dir / "plan.json"
+
+    lines: List[str] = ["# DriftGuard Change Plan", ""]
+    json_payload: Dict[str, List[Dict[str, object]]] = {"devices": []}
+
+    for snippet in all_snippets:
+        lines.append(f"## {snippet.device}")
+        lines.append("")
+        lines.append("```")
+        for command in snippet.commands:
+            lines.append(command)
+        lines.append("```")
+        lines.append("")
+        json_payload["devices"].append(
+            {
+                "device": snippet.device,
+                "rules": list(snippet.rule_ids),
+                "commands": list(snippet.commands),
+                "path": str(snippet.path),
+            }
+        )
+
+    plan_md.write_text("\n".join(lines) + "\n")
+    import json
+
+    plan_json.write_text(json.dumps(json_payload, indent=2))
+
+    return ChangePlan(plan_md=plan_md, plan_json=plan_json, snippets=all_snippets)

--- a/onyxlib/drift/report.py
+++ b/onyxlib/drift/report.py
@@ -1,0 +1,77 @@
+"""Rendering of DriftGuard reports and metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+import json
+
+from .rules import SEVERITY_ORDER
+
+
+@dataclass
+class DeviceSummary:
+    device: str
+    worst_severity: str | None
+    failed_rules: List[str]
+    diff_path: str
+    remediation_paths: List[str]
+    diff_lines: int
+
+
+@dataclass
+class DriftReport:
+    markdown_path: Path
+    json_path: Path
+    metrics_path: Path
+    device_summaries: List[DeviceSummary]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "devices": [summary.__dict__ for summary in self.device_summaries],
+        }
+
+
+def render_markdown(summaries: Sequence[DeviceSummary]) -> str:
+    lines = ["# DriftGuard Report", ""]
+    lines.append("| Device | Worst Severity | Failed Rules | Diff | Remediation | Diff Lines |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for summary in summaries:
+        rules_text = ", ".join(summary.failed_rules) if summary.failed_rules else "-"
+        remediation_text = ", ".join(summary.remediation_paths) if summary.remediation_paths else "-"
+        lines.append(
+            f"| {summary.device} | {summary.worst_severity or '-'} | {rules_text} | {summary.diff_path} | {remediation_text} | {summary.diff_lines} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_report(out_dir: Path, summaries: Sequence[DeviceSummary]) -> DriftReport:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    markdown_path = out_dir / "drift_report.md"
+    json_path = out_dir / "drift_report.json"
+    metrics_path = out_dir / "metrics.json"
+
+    markdown_path.write_text(render_markdown(summaries))
+    json_path.write_text(json.dumps({"devices": [summary.__dict__ for summary in summaries]}, indent=2))
+
+    drift_count = sum(1 for summary in summaries if summary.failed_rules)
+    critical_count = sum(1 for summary in summaries if summary.worst_severity == "critical")
+    mean_drift = 0.0
+    if summaries:
+        mean_drift = sum(summary.diff_lines for summary in summaries) / len(summaries)
+
+    metrics = {
+        "drift_count": drift_count,
+        "critical_count": critical_count,
+        "mean_drift_lines": round(mean_drift, 2),
+    }
+    metrics_path.write_text(json.dumps(metrics, indent=2))
+
+    return DriftReport(
+        markdown_path=markdown_path,
+        json_path=json_path,
+        metrics_path=metrics_path,
+        device_summaries=list(summaries),
+    )

--- a/onyxlib/drift/rules.py
+++ b/onyxlib/drift/rules.py
@@ -1,0 +1,132 @@
+"""Rules-as-code engine for DriftGuard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import yaml
+
+from .normalizer import join_lines
+
+SEVERITY_ORDER = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+
+@dataclass
+class Rule:
+    rule_id: str
+    severity: str
+    contains_lines: Sequence[str]
+    not_contains_lines: Sequence[str]
+    remediation: Sequence[str]
+    platforms: Optional[Sequence[str]] = None
+
+    def applies_to(self, platform: str) -> bool:
+        if not self.platforms:
+            return True
+        return platform in self.platforms
+
+    def evaluate(self, config_lines: Sequence[str]) -> "RuleResult":
+        config_blob = join_lines(config_lines)
+        missing: List[str] = []
+        unexpected: List[str] = []
+
+        for line in self.contains_lines:
+            if line not in config_blob:
+                missing.append(line)
+        for line in self.not_contains_lines:
+            if line in config_blob:
+                unexpected.append(line)
+
+        passed = not missing and not unexpected
+        reason_parts: List[str] = []
+        if missing:
+            reason_parts.append(f"missing: {', '.join(missing)}")
+        if unexpected:
+            reason_parts.append(f"unexpected: {', '.join(unexpected)}")
+        reason = "; ".join(reason_parts)
+
+        return RuleResult(rule=self, passed=passed, reason=reason)
+
+
+@dataclass
+class RuleResult:
+    rule: Rule
+    passed: bool
+    reason: str
+
+    @property
+    def severity(self) -> str:
+        return self.rule.severity
+
+    def is_failure(self) -> bool:
+        return not self.passed
+
+
+class RulesEngine:
+    """Loads and evaluates DriftGuard rules."""
+
+    def __init__(self, rules: Sequence[Rule]):
+        self._rules = list(rules)
+
+    @classmethod
+    def from_path(cls, rules_path: Path) -> "RulesEngine":
+        rules: List[Rule] = []
+        rules_dir = Path(rules_path)
+        for path in sorted(rules_dir.glob("*.yml")) + sorted(rules_dir.glob("*.yaml")):
+            rules.extend(_parse_rules_file(path))
+        return cls(rules)
+
+    def evaluate(self, platform: str, config_lines: Sequence[str]) -> List[RuleResult]:
+        return [rule.evaluate(config_lines) for rule in self._rules if rule.applies_to(platform)]
+
+    def worst_severity(self, results: Sequence[RuleResult]) -> Optional[str]:
+        failing = [result.severity for result in results if result.is_failure()]
+        if not failing:
+            return None
+        return max(failing, key=lambda sev: SEVERITY_ORDER.get(sev, -1))
+
+
+def _parse_rules_file(path: Path) -> List[Rule]:
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"Rules file {path} must be a mapping")
+    raw_rules = data.get("rules")
+    if not isinstance(raw_rules, list):
+        raise ValueError(f"Rules file {path} must contain a 'rules' list")
+    platforms = data.get("platforms")
+    platforms_list = list(platforms) if isinstance(platforms, (list, tuple)) else None
+
+    parsed: List[Rule] = []
+    for raw in raw_rules:
+        if not isinstance(raw, dict):
+            raise ValueError(f"Rule entries must be mappings in {path}")
+        rule_id = str(raw.get("id"))
+        severity = str(raw.get("severity", "medium")).lower()
+        if severity not in SEVERITY_ORDER:
+            raise ValueError(f"Rule {rule_id} has invalid severity '{severity}'")
+        match_block = raw.get("match", {})
+        contains = []
+        not_contains = []
+        if isinstance(match_block, dict):
+            contains = list(match_block.get("contains_lines", []) or [])
+            not_contains = list(match_block.get("not_contains_lines", []) or [])
+        remediate_block = raw.get("remediate", {})
+        commands: Sequence[str] = []
+        if isinstance(remediate_block, dict):
+            commands = list(remediate_block.get("commands", []) or [])
+        rule_platforms = platforms_list
+        if isinstance(raw.get("platforms"), (list, tuple)):
+            rule_platforms = list(raw.get("platforms"))
+        parsed.append(
+            Rule(
+                rule_id=rule_id,
+                severity=severity,
+                contains_lines=contains,
+                not_contains_lines=not_contains,
+                remediation=commands,
+                platforms=rule_platforms,
+            )
+        )
+    return parsed

--- a/rules/cisco.yml
+++ b/rules/cisco.yml
@@ -1,0 +1,25 @@
+platforms:
+  - cisco_ios
+rules:
+  - id: ntp_servers
+    severity: medium
+    match:
+      contains_lines:
+        - "ntp server 1.1.1.1"
+        - "ntp server 1.0.0.1"
+    remediate:
+      commands:
+        - "conf t"
+        - "ntp server 1.1.1.1"
+        - "ntp server 1.0.0.1"
+        - "end"
+  - id: no_http_server
+    severity: high
+    match:
+      not_contains_lines:
+        - "ip http server"
+    remediate:
+      commands:
+        - "conf t"
+        - "no ip http server"
+        - "end"

--- a/scripts/driftguard.py
+++ b/scripts/driftguard.py
@@ -1,0 +1,105 @@
+"""CLI entrypoint for DriftGuard policy-as-code drift detection."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+from onyxlib.drift.diff import build_diff
+from onyxlib.drift.loader import DeviceRecord, load_device_configs, load_inventory
+from onyxlib.drift.normalizer import normalize_config
+from onyxlib.drift.remediation import ChangePlan, build_change_plan
+from onyxlib.drift.report import DeviceSummary, write_report
+from onyxlib.drift.rules import RulesEngine, SEVERITY_ORDER
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="DriftGuard config drift detection")
+    parser.add_argument("--inventory", required=True, help="Path to inventory YAML")
+    parser.add_argument("--configs", required=True, help="Directory containing configs")
+    parser.add_argument("--rules", required=True, help="Directory containing rules YAML")
+    parser.add_argument("--out", required=True, help="Directory for output artifacts")
+    parser.add_argument("--render-remediation", action="store_true", help="Render remediation previews")
+    parser.add_argument(
+        "--fail-on",
+        default="critical",
+        choices=list(SEVERITY_ORDER.keys()),
+        help="Fail CI when drift at or above severity occurs",
+    )
+    parser.add_argument("--offline", action="store_true", help="Run in offline demonstration mode")
+    return parser.parse_args()
+
+
+def evaluate_device(device: DeviceRecord, engine: RulesEngine, diffs_dir: Path) -> Dict[str, object]:
+    running_lines = normalize_config(device.running_config)
+    baseline_lines = normalize_config(device.baseline_config or "")
+    diff = build_diff(device.name, baseline_lines, running_lines, diffs_dir)
+    rule_results = engine.evaluate(device.platform, running_lines)
+    return {
+        "device": device,
+        "diff": diff,
+        "rule_results": rule_results,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    inventory_entries = load_inventory(Path(args.inventory))
+    devices = load_device_configs(inventory_entries, Path(args.configs))
+    engine = RulesEngine.from_path(Path(args.rules))
+
+    out_dir = Path(args.out)
+    diffs_dir = out_dir / "diffs"
+    reports_dir = out_dir
+
+    evaluation: List[Dict[str, object]] = []
+    for device in devices:
+        evaluation.append(evaluate_device(device, engine, diffs_dir))
+
+    device_to_results: Dict[str, List] = {}
+    summaries: List[DeviceSummary] = []
+    highest_severity = None
+
+    for item in evaluation:
+        device: DeviceRecord = item["device"]
+        diff = item["diff"]
+        results = item["rule_results"]
+        device_to_results[device.name] = results
+        failed_rules = [result.rule.rule_id for result in results if not result.passed]
+        worst = engine.worst_severity(results)
+        if worst and (highest_severity is None or SEVERITY_ORDER[worst] > SEVERITY_ORDER.get(highest_severity, -1)):
+            highest_severity = worst
+        summaries.append(
+            DeviceSummary(
+                device=device.name,
+                worst_severity=worst,
+                failed_rules=failed_rules,
+                diff_path=str(diff.diff_path),
+                remediation_paths=[],
+                diff_lines=diff.line_count,
+            )
+        )
+
+    remediation_plan: ChangePlan | None = None
+    if args.render_remediation:
+        remediation_plan = build_change_plan(device_to_results, out_dir)
+        by_device: Dict[str, List[str]] = {}
+        for snippet in remediation_plan.snippets:
+            by_device.setdefault(snippet.device, []).append(snippet.path.name)
+        for summary in summaries:
+            summary.remediation_paths = by_device.get(summary.device, [])
+
+    write_report(reports_dir, summaries)
+
+    fail_threshold = args.fail_on
+    exit_code = 0
+    if highest_severity and SEVERITY_ORDER[highest_severity] >= SEVERITY_ORDER[fail_threshold]:
+        exit_code = 2
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - handled by CLI invocation
+    sys.exit(main())

--- a/tests/test_driftguard_cli.py
+++ b/tests/test_driftguard_cli.py
@@ -1,0 +1,103 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def _write_inventory(path: Path, devices: list[dict]):
+    path.write_text(yaml.dump({"devices": devices}))
+
+
+def test_driftguard_cli_integration(tmp_path: Path):
+    inventory_path = tmp_path / "inventory.yml"
+    configs_dir = tmp_path / "configs"
+    baseline_dir = configs_dir / "baseline"
+    baseline_dir.mkdir(parents=True)
+
+    running_config = """
+    hostname core-sw01
+    ip http server
+    ntp server 1.1.1.1
+    """
+    baseline_config = """
+    hostname core-sw01
+    ntp server 1.1.1.1
+    ntp server 1.0.0.1
+    """
+    (configs_dir / "core-sw01.running.cfg").write_text(running_config)
+    (baseline_dir / "core-sw01.cfg").write_text(baseline_config)
+
+    _write_inventory(
+        inventory_path,
+        [
+            {
+                "name": "core-sw01",
+                "platform": "cisco_ios",
+            }
+        ],
+    )
+
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    rules_dir.joinpath("cisco.yml").write_text(
+        yaml.dump(
+            {
+                "platforms": ["cisco_ios"],
+                "rules": [
+                    {
+                        "id": "require-ntp",
+                        "severity": "medium",
+                        "match": {"contains_lines": ["ntp server 1.0.0.1"]},
+                        "remediate": {"commands": ["conf t", "ntp server 1.0.0.1", "end"]},
+                    },
+                    {
+                        "id": "block-http",
+                        "severity": "critical",
+                        "match": {"not_contains_lines": ["ip http server"]},
+                        "remediate": {"commands": ["conf t", "no ip http server", "end"]},
+                    },
+                ],
+            }
+        )
+    )
+
+    out_dir = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        "-m",
+        "scripts.driftguard",
+        "--inventory",
+        str(inventory_path),
+        "--configs",
+        str(configs_dir),
+        "--rules",
+        str(rules_dir),
+        "--out",
+        str(out_dir),
+        "--render-remediation",
+        "--fail-on",
+        "critical",
+        "--offline",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 2, result.stderr
+
+    report_md = out_dir / "drift_report.md"
+    metrics_json = out_dir / "metrics.json"
+    plan_md = out_dir / "plan.md"
+    plan_json = out_dir / "plan.json"
+    remediation_dir = out_dir / "remediation"
+
+    assert report_md.exists()
+    assert metrics_json.exists()
+    assert plan_md.exists()
+    assert plan_json.exists()
+    remediation_files = list(remediation_dir.glob("*.txt"))
+    assert remediation_files, "expected remediation snippets"
+
+    metrics = json.loads(metrics_json.read_text())
+    assert metrics["critical_count"] == 1
+    assert metrics["drift_count"] == 1

--- a/tests/test_driftguard_diff.py
+++ b/tests/test_driftguard_diff.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from onyxlib.drift.diff import build_diff
+
+
+def test_build_diff_writes_file(tmp_path: Path):
+    out = tmp_path / "diffs"
+    result = build_diff(
+        device="device1",
+        baseline_lines=["line1", "line2"],
+        running_lines=["line1", "line3"],
+        out_dir=out,
+    )
+    assert result.diff_path.exists()
+    content = result.diff_path.read_text()
+    assert "-line2" in content
+    assert "+line3" in content
+    assert result.line_count == 2

--- a/tests/test_driftguard_normalizer.py
+++ b/tests/test_driftguard_normalizer.py
@@ -1,0 +1,18 @@
+from onyxlib.drift.normalizer import normalize_config
+
+
+def test_normalize_config_filters_comments_and_whitespace():
+    raw = """
+    ! comment
+    ip   http  server
+
+      interface Gi0/1
+       description  Uplink
+    # another comment
+    """
+    normalized = normalize_config(raw)
+    assert normalized == [
+        "ip http server",
+        "interface Gi0/1",
+        "description Uplink",
+    ]

--- a/tests/test_driftguard_rules.py
+++ b/tests/test_driftguard_rules.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import yaml
+
+from onyxlib.drift.normalizer import normalize_config
+from onyxlib.drift.rules import RulesEngine
+
+
+def test_rules_engine_parses_platforms(tmp_path: Path):
+    rules_file = tmp_path / "rules.yml"
+    rules_file.write_text(
+        yaml.dump(
+            {
+                "platforms": ["cisco_ios"],
+                "rules": [
+                    {
+                        "id": "ntp",
+                        "severity": "high",
+                        "match": {"contains_lines": ["ntp server 1.1.1.1"]},
+                        "remediate": {"commands": ["conf t", "ntp server 1.1.1.1", "end"]},
+                    }
+                ],
+            }
+        )
+    )
+
+    engine = RulesEngine.from_path(tmp_path)
+    config_lines = normalize_config("ntp server 1.1.1.1\n")
+    results = engine.evaluate("cisco_ios", config_lines)
+    assert len(results) == 1
+    assert results[0].passed
+
+    other_results = engine.evaluate("juniper_junos", config_lines)
+    assert other_results == []
+
+
+def test_rules_engine_worst_severity(tmp_path: Path):
+    rules_file = tmp_path / "rules.yml"
+    rules_file.write_text(
+        yaml.dump(
+            {
+                "rules": [
+                    {
+                        "id": "crit",
+                        "severity": "critical",
+                        "match": {"contains_lines": ["foo"]},
+                        "remediate": {"commands": ["foo"]},
+                    },
+                    {
+                        "id": "low",
+                        "severity": "low",
+                        "match": {"contains_lines": ["bar"]},
+                        "remediate": {"commands": ["bar"]},
+                    },
+                ]
+            }
+        )
+    )
+
+    engine = RulesEngine.from_path(tmp_path)
+    results = engine.evaluate("any", normalize_config("bar\n"))
+    # Only low rule passes, critical fails.
+    assert engine.worst_severity(results) == "critical"


### PR DESCRIPTION
## Summary
- implement DriftGuard drift detection CLI with rules engine, normalization, diffing, remediation previews, and reporting
- add sample inventory, rules, and Cisco IOS configs to enable offline demonstration
- introduce automated tests and CI workflow covering DriftGuard functionality and publishing artifacts

## Testing
- pytest -q
- python -m scripts.driftguard --inventory inventory.yml --configs configs --rules rules --out out/drift --render-remediation --fail-on critical --offline

------
https://chatgpt.com/codex/tasks/task_e_68d451057fec832da0d8b2fe5fd82f0e